### PR TITLE
Validated .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
         "node": true,
         "mocha": true
     },
-    "extends": "eslint:recommended",
+    "extends": ["eslint:recommended"],
     "parser": "babel-eslint",
     "parserOptions": {
         "ecmaVersion": 12


### PR DESCRIPTION
extends property of `.eslintrc.json` should be in an array format.